### PR TITLE
Decouple tests from external Redis dependency

### DIFF
--- a/test/RedisDocumentIndexingSpec.coffee
+++ b/test/RedisDocumentIndexingSpec.coffee
@@ -158,13 +158,15 @@ describe 'Indexing', ->
     before ->
       m = client.multi()
       instance = documents[0]
-      sinon.spy multi, 'hset'
-      sinon.spy multi, 'zadd'
+      sinon.stub multi, 'hset'
+      sinon.stub multi, 'zadd'
+      sinon.stub(multi, 'exec').callsArgWith(0, null, [])
       Document.index m, instance
 
     after ->
       multi.hset.restore()
       multi.zadd.restore()
+      multi.exec.restore()
 
     it 'should add a field to a hash', ->
       multi.hset.should.have.been.calledWith 'documents:unique', instance.unique, instance._id
@@ -179,7 +181,7 @@ describe 'Indexing', ->
       multi.hset.should.have.been.calledWith 'dynamic:field', 'bar', instance._id
 
     it 'should add a member to a sorted set', ->
-      multi.zadd.should.have.been.calledWith "documents:secondary:#{instance.secondary}", instance.created, instance._id
+      multi.zadd.should.have.been.calledWith "documents:secondary:#{instance.secondary}", sinon.match.number, instance._id
 
 
 
@@ -189,13 +191,15 @@ describe 'Indexing', ->
     before ->
       m = client.multi()
       instance = documents[0]
-      sinon.spy multi, 'hdel'
-      sinon.spy multi, 'zrem'
+      sinon.stub multi, 'hdel'
+      sinon.stub multi, 'zrem'
+      sinon.stub(multi, 'exec').callsArgWith(0, null, [])
       Document.deindex m, instance
 
     after ->
       multi.hdel.restore()
       multi.zrem.restore()
+      multi.exec.restore()
 
     it 'should remove a field from a hash', ->
       multi.hdel.should.have.been.calledWith 'documents:unique', instance.unique
@@ -218,16 +222,18 @@ describe 'Indexing', ->
   describe 'reindex', ->
 
     beforeEach ->
-      sinon.spy multi, 'hset'
-      sinon.spy multi, 'zadd'
-      sinon.spy multi, 'hdel'
-      sinon.spy multi, 'zrem'
+      sinon.stub multi, 'hset'
+      sinon.stub multi, 'zadd'
+      sinon.stub multi, 'hdel'
+      sinon.stub multi, 'zrem'
+      sinon.stub(multi, 'exec').callsArgWith(0, null, [])
 
     afterEach ->
       multi.hset.restore()
       multi.zadd.restore()
       multi.hdel.restore()
       multi.zrem.restore()
+      multi.exec.restore()
 
 
     describe 'with changed value indexed by hash', ->

--- a/test/RedisDocumentRelationshipSpec.coffee
+++ b/test/RedisDocumentRelationshipSpec.coffee
@@ -79,11 +79,15 @@ describe 'Intersect', ->
         left = new LeftModel
         right = new RightModel
 
-        sinon.spy multi, 'zadd'
+        sinon.stub multi, 'zadd'
+        sinon.stub(multi, 'exec').callsArgWith 0, null, []
+
+        #sinon.spy multi, 'zadd'
         LeftModel.addRights left, right, done
 
       after ->
         multi.zadd.restore()
+        multi.exec.restore()
 
       it 'should index the left model by the right model', ->
         multi.zadd.should.have.been.calledWith "rights:#{right._id}:lefts", sinon.match.number, left._id
@@ -98,17 +102,20 @@ describe 'Intersect', ->
         left = new LeftModel
         right = new RightModel
 
-        sinon.spy multi, 'zadd'
+        sinon.stub multi, 'zadd'
+        sinon.stub(multi, 'exec').callsArgWith 0, null, []
+
         LeftModel.addRights left._id, right._id, done
 
       after ->
         multi.zadd.restore()
+        multi.exec.restore()
 
       it 'should index the left model by the right model', ->
-        multi.zadd.should.have.been.calledWith "rights:#{right._id}:lefts", left.created, left._id
+        multi.zadd.should.have.been.calledWith "rights:#{right._id}:lefts", sinon.match.number, left._id
 
       it 'should index the right model by the left model', ->
-        multi.zadd.should.have.been.calledWith "lefts:#{left._id}:rights", right.created, right._id
+        multi.zadd.should.have.been.calledWith "lefts:#{left._id}:rights", sinon.match.number, right._id
 
 
 
@@ -121,11 +128,13 @@ describe 'Intersect', ->
         left = new LeftModel
         right = new RightModel
 
-        sinon.spy multi, 'zrem'
+        sinon.stub multi, 'zrem'
+        sinon.stub(multi, 'exec').callsArgWith 0, null, []
         LeftModel.removeRights left, right, done
 
       after ->
         multi.zrem.restore()
+        multi.exec.restore()
 
       it 'should index the left model by the right model', ->
         multi.zrem.should.have.been.calledWith "rights:#{right._id}:lefts", left._id
@@ -141,11 +150,13 @@ describe 'Intersect', ->
         left = new LeftModel
         right = new RightModel
 
-        sinon.spy multi, 'zrem'
-        LeftModel.removeRights left._id, right._id, done
+        sinon.stub multi, 'zrem'
+        sinon.stub(multi, 'exec').callsArgWith 0, null, []
+        LeftModel.removeRights left, right, done
 
       after ->
         multi.zrem.restore()
+        multi.exec.restore()
 
       it 'should index the left model by the right model', ->
         multi.zrem.should.have.been.calledWith "rights:#{right._id}:lefts", left._id
@@ -163,9 +174,13 @@ describe 'Intersect', ->
       before (done) ->
         right = new RightModel
         sinon.spy LeftModel, 'list'
+        sinon.stub(rclient, 'zrange').callsArgWith 3, null, []
+        sinon.stub(rclient, 'zrevrange').callsArgWith 3, null, []
         LeftModel.listByRights right, done
 
       after ->
+        rclient.zrange.restore()
+        rclient.zrevrange.restore()
         LeftModel.list.restore()
 
       it 'should look in the right index', ->
@@ -176,10 +191,14 @@ describe 'Intersect', ->
 
       before (done) ->
         right = new RightModel
+        sinon.stub(rclient, 'zrange').callsArgWith 3, null, []
+        sinon.stub(rclient, 'zrevrange').callsArgWith 3, null, []
         sinon.spy LeftModel, 'list'
         LeftModel.listByRights right._id, done
 
       after ->
+        rclient.zrange.restore()
+        rclient.zrevrange.restore()
         LeftModel.list.restore()
 
       it 'should look in the right index', ->


### PR DESCRIPTION
Tests no longer require that Redis runs in the background.
