### PR TITLE
Use ioredis

### DIFF
--- a/lib/RedisDocument.js
+++ b/lib/RedisDocument.js
@@ -295,8 +295,8 @@ RedisDocument.delete = function (id, callback) {
     })
 
     // execute the set of ops
-    multi.exec(function (err) {
-      if (err) { callback(err) }
+    multi.exec(function (err, result) {
+      if (err) { return callback(err) }
       callback(null, true)
     })
   })

--- a/package.json
+++ b/package.json
@@ -37,8 +37,8 @@
   },
   "dependencies": {
     "async": "^1.3.0",
-    "modinha": "0.0.30",
-    "redis": "^0.12.1"
+    "ioredis": "^1.7.5",
+    "modinha": "0.0.30"
   },
   "bugs": {
     "url": "https://github.com/anvilresearch/modinha-redis/issues"

--- a/test/RedisDocumentIndexingSpec.coffee
+++ b/test/RedisDocumentIndexingSpec.coffee
@@ -5,6 +5,7 @@ Faker     = require 'faker'
 chai      = require 'chai'
 sinon     = require 'sinon'
 sinonChai = require 'sinon-chai'
+mockMulti = require './lib/multi'
 expect    = chai.expect
 
 
@@ -25,10 +26,10 @@ RedisDocument = require path.join(cwd, 'lib/RedisDocument')
 
 
 # Redis lib for spying and stubbing
-redis   = require 'redis'
-client  = redis.createClient()
-multi   = redis.Multi.prototype
-rclient = redis.RedisClient.prototype
+Redis   = require 'ioredis'
+client  = new Redis({ port: 12345 })
+rclient = Redis.prototype
+multi   = mockMulti(rclient)
 
 
 
@@ -96,7 +97,7 @@ describe 'Indexing', ->
       field: ['$', ['nested.$', 'flag']]
       value: '_id'
 
-    Document.__redis = redis
+    Document.__redis = Redis
     Document.__client = client
 
     # Mock data

--- a/test/RedisDocumentRelationshipSpec.coffee
+++ b/test/RedisDocumentRelationshipSpec.coffee
@@ -5,6 +5,7 @@ path      = require 'path'
 chai      = require 'chai'
 sinon     = require 'sinon'
 sinonChai = require 'sinon-chai'
+mockMulti = require './lib/multi'
 expect    = chai.expect
 
 
@@ -24,11 +25,11 @@ RedisDocument = require path.join(cwd, 'lib/RedisDocument')
 
 
 
-## Redis lib for spying and stubbing
-redis   = require 'redis'
-client  = redis.createClient()
-multi   = redis.Multi.prototype
-rclient = redis.RedisClient.prototype
+# Redis lib for spying and stubbing
+Redis   = require 'ioredis'
+client  = new Redis({ port: 12345 })
+rclient = Redis.prototype
+multi   = mockMulti(rclient)
 
 
 

--- a/test/RedisDocumentSpec.coffee
+++ b/test/RedisDocumentSpec.coffee
@@ -5,6 +5,7 @@ faker     = require 'faker'
 chai      = require 'chai'
 sinon     = require 'sinon'
 sinonChai = require 'sinon-chai'
+mockMulti = require './lib/multi'
 expect    = chai.expect
 
 
@@ -25,13 +26,10 @@ RedisDocument = require path.join(cwd, 'lib/RedisDocument')
 
 
 # Redis lib for spying and stubbing
-redis   = require 'redis'
-multi   = redis.Multi.prototype
-rclient = redis.RedisClient.prototype
-rclient.ready_check = ->
-rclient.install_stream_listeners = ->
-rclient.connection_gone = ->
-client  = new redis.RedisClient({}, {})
+Redis   = require 'ioredis'
+client  = new Redis({ port: 12345 })
+rclient = Redis.prototype
+multi   = mockMulti(rclient)
 
 
 
@@ -58,7 +56,7 @@ describe 'RedisDocument', ->
     Document.extend RedisDocument
 
 
-    Document.__redis = redis
+    Document.__redis = Redis
     Document.__client = client
 
     # Mock data

--- a/test/lib/multi.coffee
+++ b/test/lib/multi.coffee
@@ -1,0 +1,29 @@
+Redis = require 'ioredis'
+client = Redis.prototype
+
+multi = {}
+multiOld = client.multi
+multiMethods = []
+
+for key of client
+  if typeof client[key] == 'function'
+    multiMethods.push key
+
+multiMethods.forEach (prop) ->
+  multi[prop] = ->
+    multi
+  return
+
+multi.exec = ->
+  throw new Error('exec called without being stubbed')
+  return
+
+module.exports = (client) ->
+  client.multi = ->
+    multi
+
+  client.multi.restore = ->
+    client.multi = multiOld
+    return
+
+  multi


### PR DESCRIPTION
## Overview
- Helps fix https://github.com/anvilresearch/connect/issues/125
- **Required for https://github.com/anvilresearch/connect/pull/188**
## To do
1. Review this PR
2. Review https://github.com/anvilresearch/connect/pull/188
3. Merge this PR
4. Document changes
5. Release new modinha-redis version
6. Follow steps at https://github.com/anvilresearch/connect/pull/188
## Details

**Local tests:**
- All 188 unit tests pass
- Tested successfully in conjunction with https://github.com/anvilresearch/connect/pull/188

**Implications:**
- ioredis `multi.exec()` returns an array of arrays for results instead of a flat array as does node-redis, with the first element of each sub-array the error from the command, and the second the results. _We do not make any attempt to flatten the array in modinha-redis._
